### PR TITLE
Implement decomp yamls for [coddog](https://github.com/ethteck/coddog)

### DIFF
--- a/banjo-kazooie.decomp.yaml
+++ b/banjo-kazooie.decomp.yaml
@@ -1,0 +1,25 @@
+name: Banjo-Kazooie
+github: https://github.com/n64decomp/banjo-kazooie
+platform: n64
+versions:
+- name: us
+  fullname: US
+  sha1: 1fe1632098865f639e22c11b9a81ee8f29c75d7a
+  paths:
+    baserom: "../banjo-kazooie/baserom.us.v10.z64"
+    build: "../banjo-kazooie/build/us.v10/banjo.us.v10.uncompressed"
+    asm: "../banjo-kazooie/asm"
+    nonmatchings: "../banjo-kazooie/asm/nonmatchings"
+    map: "../banjo-kazooie/build/us.v10/banjo.us.v10.map"
+    elf: "../banjo-kazooie/build/us.v10/banjo.us.v10.elf"
+tools:
+#  decompme:
+#    preset: 0
+  permuter:
+    decompme_compilers:
+      tools/ido/cc: ido5.3
+#  frogress:
+#    project: banjo-kazooie
+#    versions:
+#      us: # corresponds with top-level version snames
+#        version: us

--- a/banjo-kazooie.decomp.yaml
+++ b/banjo-kazooie.decomp.yaml
@@ -7,7 +7,7 @@ versions:
   sha1: 1fe1632098865f639e22c11b9a81ee8f29c75d7a
   paths:
     baserom: "../banjo-kazooie/baserom.us.v10.z64"
-    build: "../banjo-kazooie/build/us.v10/banjo.us.v10.uncompressed"
+    build: "../banjo-kazooie/build/us.v10/banjo.us.v10.uncompressed.z64"
     asm: "../banjo-kazooie/asm"
     nonmatchings: "../banjo-kazooie/asm/nonmatchings"
     map: "../banjo-kazooie/build/us.v10/banjo.us.v10.map"

--- a/banjo-tooie.decomp.yaml
+++ b/banjo-tooie.decomp.yaml
@@ -1,0 +1,25 @@
+name: Banjo-Tooie
+github: https://github.com/Mr-Wiseguy/banjo-tooie
+platform: n64
+versions:
+- name: us
+  fullname: US
+  sha1: af1a89e12b638b8d82cc4c085c8e01d4cba03fb3
+  paths:
+    baserom: "baserom.us.z64"
+    build: "build/us/banjotooie_decompressed.z64"
+    asm: "asm"
+    nonmatchings: "asm/nonmatchings"
+    map: "build/us/banjotooie_decompressed.map"
+    elf: "build/us/banjotooie_decompressed.elf"
+tools:
+#  decompme:
+#    preset: 0
+  permuter:
+    decompme_compilers:
+      tools/ido/cc: ido5.3
+#  frogress:
+#    project: banjo-tooie
+#    versions:
+#      us: # corresponds with top-level version snames
+#        version: us


### PR DESCRIPTION
Related to issue #1 
To use, build this repo and banjo-kazooie (bk should be in ../banjo-kazooie for now) and run `coddog compare2 banjo-tooie.decomp.yaml us banjo-kazooie.decomp.yaml`

Draft for now.