### PR TITLE
chore: Move function definitions into their "correct" header files #3

### DIFF
--- a/include/ba/1E72EA0.h
+++ b/include/ba/1E72EA0.h
@@ -18,9 +18,10 @@ typedef struct ba_unknown_C0_s {
     u8 pad24[0xCC];
 } BaUnknownC0;
 
-f32 func_80099A34(PlayerState *self);
+void func_800995B8(PlayerState *, s32);
+f32 func_80099A34(PlayerState *);
 void func_80099B94(PlayerState *);
-f32 func_80099A40(PlayerState *self);
+f32 func_80099A40(PlayerState *);
 void func_8009AB78(PlayerState *);
 
 #endif // __BA_1E72EA0_H__

--- a/include/ba/data.h
+++ b/include/ba/data.h
@@ -1,0 +1,108 @@
+#ifndef __BA_DATA_H__
+#define __BA_DATA_H__
+
+#include <ultra64.h>
+#include "common.h"
+
+#include "ba/assets.h"
+#include "ba/statetimer.h"
+#include "core2/1E6F080.h"
+#include "core2/1E75920.h"
+#include "core2/1EB5980.h"
+
+typedef struct {
+    s16 unk0;
+    s16 unk2;
+    f32 unk4;
+} BaData_1;
+
+typedef struct {
+    BaData_1 *unk0;
+    s32 count;
+    f32 unk8;
+} BaData_5;
+
+typedef struct {
+    s16 unk0;
+    s16 unk2;
+    f32 unk4;
+    f32 unk8;
+} BaData_4;
+
+typedef struct {
+    s16 unk0;
+    s16 unk2;
+    f32 unk4;
+    f32 unk8;
+    f32 unkC;
+} BaData_3;
+
+typedef struct {
+    s16 unk0;
+    s16 unk2;
+    s16 unk4;
+} BaData_2;
+
+extern BaData_5 D_808010C8_badata[];
+extern BaData_5 D_80801298_badata[];
+extern s16 D_80801448_badata[];
+extern s16 D_80801490_badata[];
+extern s16 D_808014D8_badata[];
+extern s16 D_80801520_badata[];
+extern BaData_2 D_80801568_badata[];
+extern u8 D_80801640_badata[];
+extern u8 D_80801664_badata[];
+extern s32 D_80801688_badata[];
+extern BaData_3 D_80801718_badata[];
+extern BaData_1 D_80801958_badata[];
+extern BaData_1 D_80801A78_badata[];
+extern BaData_1 D_80801B98_badata[];
+extern BaData_1 D_80801CB8_badata[];
+extern BaData_1 D_80801DD8_badata[];
+extern BaData_1 D_80801EF8_badata[];
+extern BaData_1 D_80802018_badata[];
+extern BaData_1 D_80802138_badata[];
+extern BaData_1 D_80802258_badata[];
+extern BaData_1 D_80802378_badata[];
+extern BaData_4 D_80802498_badata[];
+extern BaData_4 D_80802648_badata[];
+
+extern void _badata_entrypoint_0(PlayerState *self, AssetId *assetId, f32 *arg2);
+extern void _badata_entrypoint_1(PlayerState *self, AssetId *assetId, f32 *arg2);
+extern void _badata_entrypoint_2(PlayerState *self, AssetId *assetId, f32 *arg2);
+extern void _badata_entrypoint_3(PlayerState *self, AssetId *assetId, f32 *arg2);
+extern void _badata_entrypoint_4(PlayerState *self, AssetId *assetId, f32 *arg2);
+extern void _badata_entrypoint_5(PlayerState *self, AssetId *assetId, f32 *arg2);
+extern void _badata_entrypoint_6(PlayerState *self, s32 *arg1, f32 *arg2, f32 *arg3, f32 *arg4);
+extern void _badata_entrypoint_7(PlayerState * self, AssetId *assetId, f32 *arg2);
+extern void _badata_entrypoint_8(PlayerState *self, s32 *arg1, f32 *arg2, f32 *arg3);
+extern void _badata_entrypoint_9(PlayerState *self, AssetId *assetId, f32 *arg2);
+extern void _badata_entrypoint_10(PlayerState *self, AssetId *assetId, f32 *arg2);
+extern void _badata_entrypoint_11(PlayerState *self, AssetId *assetId, f32 *arg2);
+extern void _badata_entrypoint_12(PlayerState *self, s32 *arg1, f32 *arg2);
+extern void _badata_entrypoint_13(PlayerState *self, s32 *arg1, f32 *arg2);
+extern s32 _badata_entrypoint_14(PlayerState *self);
+extern s32 _badata_entrypoint_15(PlayerState *self);
+extern s32 _badata_entrypoint_16(void);
+extern void _badata_entrypoint_17(PlayerState *self, s32 index, s32 *arg2, f32 *arg3, s32 *arg4);
+extern f32 _badata_entrypoint_18(PlayerState *self);
+extern void _badata_entrypoint_19(PlayerState *self, s32 index, s32 *arg2, f32 *arg3, s32 *arg4);
+extern s32 _badata_entrypoint_20(PlayerState *self);
+extern s32 _badata_entrypoint_21(PlayerState *self);
+extern s32 _badata_entrypoint_22(PlayerState *self);
+extern s32 _badata_entrypoint_23(PlayerState *self);
+extern s32 _badata_entrypoint_24(PlayerState *self);
+extern s32 _badata_entrypoint_25(PlayerState *self);
+extern s32 _badata_entrypoint_26(PlayerState *self);
+extern s32 _badata_entrypoint_27(PlayerState *self);
+extern s32 _badata_entrypoint_28(PlayerState *self);
+extern s32 _badata_entrypoint_29(PlayerState *self);
+extern s32 _badata_entrypoint_30(PlayerState *self, s32 arg1);
+extern s32 _badata_entrypoint_31(PlayerState *self);
+// This might return a BanjoStateId
+extern s32 _badata_entrypoint_32(PlayerState *self);
+extern s32 _badata_entrypoint_33(PlayerState *self);
+extern s32 _badata_entrypoint_34(PlayerState *self);
+extern s32 _badata_entrypoint_35(PlayerState *self);
+
+#endif // __BA_DATA_H__

--- a/include/ba/physics.h
+++ b/include/ba/physics.h
@@ -23,8 +23,6 @@ typedef enum ba_physics_type_e {
     BA_PHYSICS_E_UNKNOWN
 } BaPhysicsType;
 
-
-
 void baphysics_set_type(PlayerState *, BaPhysicsType);
 void baphysics_set_vertical_velocity(PlayerState *, f32);
 void baphysics_set_target_horizontal_velocity(PlayerState* , f32 vel);
@@ -38,10 +36,15 @@ void baphysics_set_gravity(PlayerState *, f32);
 void baphysics_set_terminal_velocity(PlayerState *, f32);
 
 void func_8009B94(PlayerState *);
+void func_8009B7C0(PlayerState *);
+void func_8009BA9C(PlayerState *, f32 *);
 f32 func_8009BADC(PlayerState *);
 f32 func_8009BAE8(PlayerState *);
 void func_8009BB24(PlayerState *, f32[3]);
+f32 func_8009BB5C(PlayerState *);
+void func_8009BC34(PlayerState *);
+void func_8009BC5C(PlayerState *, f32);
+s32 func_8009BCD4(PlayerState *, f32);
 void func_8009FFD8(PlayerState *, BaAnimUpdateType anim_update_type, YawType yaw_state, s32 arg2, BaPhysicsType arg3);
-void func_8009BA9C(PlayerState *, f32 *);
 
 #endif

--- a/include/bs/drone.h
+++ b/include/bs/drone.h
@@ -1,6 +1,7 @@
 #ifndef __BS_DRONE_H__
 #define __BS_DRONE_H__
 
+#include "common.h"
 #include "ba/playerstate.h"
 
 extern void _bsdrone_entrypoint_0(PlayerState *self);

--- a/include/bs/kaz.h
+++ b/include/bs/kaz.h
@@ -1,6 +1,7 @@
 #ifndef __BS_KAZ_H__
 #define __BS_KAZ_H__
 
+#include "common.h"
 #include <ultra64.h>
 
 #include "ba/flag.h"
@@ -14,7 +15,6 @@
 #include "core2/1E6F080.h"
 #include "core2/1E78170.h"
 #include "core2/1EA0690.h"
-#include "common.h"
 
 extern void _bskaz_entrypoint_0(PlayerState *self, s32 arg1, s32 arg2);
 extern void _bskaz_entrypoint_1(PlayerState *self);

--- a/include/bs/kazcrouch.h
+++ b/include/bs/kazcrouch.h
@@ -1,7 +1,9 @@
 #ifndef __BS_KAZCROUCH_H__
 #define __BS_KAZCROUCH_H__
 
+#include "common.h"
 #include <ultra64.h>
+
 #include "an/anctrl.h"
 #include "ba/key.h"
 #include "ba/input.h"

--- a/include/bs/kazdie.h
+++ b/include/bs/kazdie.h
@@ -1,6 +1,7 @@
 #ifndef __BS_KAZDIE_H__
 #define __BS_KAZDIE_H__
 
+#include "common.h"
 #include <ultra64.h>
 
 #include "an/anctrl.h"

--- a/include/bs/kazeggass.h
+++ b/include/bs/kazeggass.h
@@ -1,6 +1,7 @@
 #ifndef __BS_KAZEGGASS_H__
 #define __BS_KAZEGGASS_H__
 
+#include "common.h"
 #include <ultra64.h>
 
 #include "an/anctrl.h"
@@ -17,7 +18,6 @@
 #include "core2/1E79FD0.h"
 #include "core2/1EA0690.h"
 #include "core2/1ECA640.h"
-#include "common.h"
 #include "funcs.h"
 
 extern void _bskazeggass_entrypoint_0(PlayerState *self);

--- a/include/bs/kazegghead.h
+++ b/include/bs/kazegghead.h
@@ -1,6 +1,9 @@
 #ifndef __BS_KAZEGGHEAD_H__
 #define __BS_KAZEGGHEAD_H__
 
+#include "common.h"
+#include <ultra64.h>
+
 #include "an/anctrl.h"
 #include "ba/playerstate.h"
 #include "ba/anim.h"

--- a/include/bs/kazflamethrower.h
+++ b/include/bs/kazflamethrower.h
@@ -1,6 +1,7 @@
 #ifndef __BS_KAZFLAMETHROWER_H__
 #define __BS_KAZFLAMETHROWER_H__
 
+#include "common.h"
 #include <ultra64.h>
 
 #include "ba/timer.h"

--- a/include/bs/kazfly.h
+++ b/include/bs/kazfly.h
@@ -1,6 +1,7 @@
 #ifndef __BS_KAZFLY_H__
 #define __BS_KAZFLY_H__
 
+#include "common.h"
 #include <ultra64.h>
 
 #include "an/anctrl.h"

--- a/include/bs/kazglide.h
+++ b/include/bs/kazglide.h
@@ -1,6 +1,7 @@
 #ifndef __BS_KAZGLIDE_H__
 #define __BS_KAZGLIDE_H__
 
+#include "common.h"
 #include <ultra64.h>
 
 #include "an/anctrl.h"
@@ -23,6 +24,7 @@
 #include "core2/1E67DA0.h"
 #include "core2/1E6B900.h"
 #include "core2/1E6F080.h"
+#include "core2/1E75620.h"
 #include "core2/1E75710.h"
 #include "core2/1E75920.h"
 #include "core2/1E76CC0.h"
@@ -36,11 +38,16 @@
 #include "funcs.h"
 #include "player.h"
 
-extern f32 func_8009630C(PlayerState *self);
-extern void func_800995B8(PlayerState *self, s32);
-extern void func_8009BC34();
-extern void func_8009BD88(PlayerState *self);
-extern s32 func_8009E69C(PlayerState *self, s32);
-extern s32 func_8009E6C4(PlayerState *self, s32);
+extern s32 D_80800AB0_bskazglide[];
+extern s32 D_80800AC0_bskazglide[];
+extern s32 D_80800AD0_bskazglide[];
+extern s32 D_80800AE0_bskazglide[];
+extern s32 D_80800AF0_bskazglide[];
+
+extern s32 _bskazglide_entrypoint_0(s32 idx);
+extern s32 _bskazglide_entrypoint_1(s32 idx);
+extern s32 _bskazglide_entrypoint_2(s32 idx);
+extern s32 _bskazglide_entrypoint_3(s32 idx);
+extern s32 _bskazglide_entrypoint_4(s32 idx);
 
 #endif // __BS_KAZGLIDE_H__

--- a/include/bs/kazhatch.h
+++ b/include/bs/kazhatch.h
@@ -1,17 +1,21 @@
 #ifndef __BS_KAZHATCH_H__
 #define __BS_KAZHATCH_H__
 
+#include "common.h"
 #include <ultra64.h>
 
 #include "ba/anim.h"
+#include "ba/data.h"
 #include "ba/physics.h"
 #include "bs/kaz.h"
 #include "bs/state.h"
 #include "core2/1E66990.h"
 #include "core2/1E76CC0.h"
+#include "core2/1EDA900.h"
 #include "funcs.h"
 
-extern BanjoStateId _badata_entrypoint_32(PlayerState *self);
-extern s32 func_8010114C(s32, s32, s32);
+extern s32 D_808004E0_bskazhatch[];
+
+extern s32 _bskazhatch_entrypoint_0(s32 idx);
 
 #endif // __BS_KAZHATCH_H__

--- a/include/bs/kazjump.h
+++ b/include/bs/kazjump.h
@@ -1,6 +1,7 @@
 #ifndef __BS_KAZJUMP_H__
 #define __BS_KAZJUMP_H__
 
+#include "common.h"
 #include <ultra64.h>
 
 #include "an/anctrl.h"
@@ -15,9 +16,11 @@
 #include "ba/yaw.h"
 #include "bs/kaz.h"
 #include "bs/kazmove.h"
+#include "bs/kazshock.h"
 #include "core2/1E66990.h"
 #include "core2/1E67DA0.h"
 #include "core2/1E6B900.h"
+#include "core2/1E6EC70.h"
 #include "core2/1E75710.h"
 #include "core2/1E76880.h"
 #include "core2/1E76CC0.h"
@@ -26,12 +29,21 @@
 #include "core2/1EA0690.h"
 #include "funcs.h"
 
-extern void _bskazshock_entrypoint_0(PlayerState *self);
-extern s32 func_8008D544(PlayerState *self);
-extern s32 func_8008E260(PlayerState *self);
-extern s32 func_8008E39C(PlayerState *self);
-extern s32 func_8009557C(PlayerState *self);
-extern void func_8009B7C0(PlayerState *self);
-extern f32 func_8009F308(PlayerState *self);
+extern void _bskazjump_entrypoint_0(PlayerState *self);
+extern void _bskazjump_entrypoint_1(PlayerState *self);
+extern void _bskazjump_entrypoint_2(PlayerState *self);
+extern s32 _bskazjump_entrypoint_3(s32 idx);
+extern void _bskazjump_entrypoint_4(PlayerState *self);
+extern void _bskazjump_entrypoint_5(PlayerState *self);
+extern void _bskazjump_entrypoint_6(PlayerState *self);
+extern s32 _bskazjump_entrypoint_7(s32 idx);
+extern void _bskazjump_entrypoint_8(PlayerState *self);
+extern void _bskazjump_entrypoint_9(PlayerState *self);
+extern void _bskazjump_entrypoint_10(PlayerState *self);
+extern s32 _bskazjump_entrypoint_11(s32 idx);
+extern void _bskazjump_entrypoint_12(PlayerState *self);
+extern void _bskazjump_entrypoint_13(PlayerState *self);
+extern void _bskazjump_entrypoint_14(PlayerState *self);
+extern s32 _bskazjump_entrypoint_15(s32 idx);
 
 #endif // __BS_KAZJUMP_H__

--- a/include/bs/kazmove.h
+++ b/include/bs/kazmove.h
@@ -1,6 +1,7 @@
 #ifndef __BS_KAZMOVE_H__
 #define __BS_KAZMOVE_H__
 
+#include "common.h"
 #include <ultra64.h>
 
 #include "an/anctrl.h"
@@ -18,26 +19,31 @@
 #include "ba/yaw.h"
 #include "bs/kaz.h"
 #include "bs/splat.h"
+#include "core2/1E66990.h"
 #include "core2/1E6F080.h"
 #include "core2/1E75710.h"
+#include "core2/1E76880.h"
 #include "core2/1E77A20.h"
+#include "core2/1E78BF0.h"
 #include "core2/1E7BFA0.h"
+#include "core2/1ECA640.h"
 #include "funcs.h"
 #include "player.h"
 
-extern s32 func_8008D790(PlayerState *self);
-extern s32 func_8008DF18(PlayerState *self);
-extern s32 func_8008E39C(PlayerState *self);
-extern f32 func_8009BB5C(PlayerState *self);
-extern s32 func_8009BCD4(PlayerState *self, f32);
-extern void func_8009D2F0(PlayerState *self, s32, f32);
-extern BanjoStateId func_800A02DC(PlayerState *self, BanjoStateId);
-extern void func_800A2D2C(PlayerState *self, f32, s32);
-extern f32 func_800F1214(f32 value, f32 min, f32 max); // ml_interpolate_f
+extern s32 D_80800C70_bskazmove[];
+extern s32 D_80800C80_bskazmove[];
 
-void _bskazmove_entrypoint_0(PlayerState *self);
-void _bskazmove_entrypoint_5(PlayerState *self, s32);
-void _bskazmove_entrypoint_6(PlayerState *self);
-void _bskazmove_entrypoint_11();
+extern void _bskazmove_entrypoint_0(PlayerState *self);
+extern void _bskazmove_entrypoint_1(PlayerState *self);
+extern void _bskazmove_entrypoint_2(PlayerState *self);
+extern void _bskazmove_entrypoint_3(PlayerState *self);
+extern s32 _bskazmove_entrypoint_4(s32 idx);
+extern void _bskazmove_entrypoint_5(PlayerState *self, s32 arg1);
+extern void _bskazmove_entrypoint_6(PlayerState *self);
+extern void _bskazmove_entrypoint_7(PlayerState *self);
+extern void _bskazmove_entrypoint_8(PlayerState *self);
+extern void _bskazmove_entrypoint_9(PlayerState *self);
+extern s32 _bskazmove_entrypoint_10(s32 idx);
+extern void _bskazmove_entrypoint_11(PlayerState *self, s32 arg1);
 
 #endif // __BS_KAZMOVE_H__

--- a/include/bs/kazow.h
+++ b/include/bs/kazow.h
@@ -12,4 +12,7 @@
 #include "funcs.h"
 #include "player.h"
 
+extern s32 _bskazow_entrypoint_0(s32 idx);
+extern s32 _bskazow_entrypoint_1(s32 idx);
+
 #endif // __BS_KAZOW_H__

--- a/include/bs/kazpaddle.h
+++ b/include/bs/kazpaddle.h
@@ -14,32 +14,28 @@
 #include "ba/stick.h"
 #include "ba/yaw.h"
 #include "bs/rest.h"
+#include "core2/1E29B60.h"
+#include "core2/1E6B900.h"
 #include "core2/1E6F080.h"
 #include "core2/1E75920.h"
 #include "core2/1E76880.h"
+#include "core2/1E76CC0.h"
+#include "core2/1E77A20.h"
 #include "core2/1E78BF0.h"
+#include "core2/1E79FD0.h"
+#include "core2/1E7BFA0.h"
 #include "core2/1E7D460.h"
+#include "core2/1E93440.h"
+#include "core2/1EB5980.h"
 #include "core2/1ECA640.h"
 #include "funcs.h"
 #include "player.h"
 
-extern s32 func_8001210C(s32);
-extern void func_80092C00(PlayerState *self, f32[3]);
-extern void func_80092C24(PlayerState *self, f32[3]);
-extern s32 func_80096500(PlayerState *self);
-extern void func_8009BC34();
-extern void func_8009BC5C(PlayerState *self, f32);
-extern void func_8009DE74(PlayerState *self, s32, f32, f32);
-extern s32 func_8009E69C(PlayerState *self, s32);
-extern s32 func_8009E6C4(PlayerState *self, s32);
-extern s32 func_8009FBB0(PlayerState *self, f32[3], f32);
-extern void func_8009FC34(PlayerState *self, s32);
-extern void func_800A1040(PlayerState *self);
-extern void func_800A106C(PlayerState *self, f32, f32);
-extern f32 func_800A3298(PlayerState *self);
-extern void func_800BA22C(s32, s32);
-extern void func_800BA930(s32, s32, s32, s32, s32, s32, s32);
-extern f32 func_800DC0C0();
-extern f32 func_800F1214(f32 value, f32 min, f32 max); // ml_interpolate_f
+extern s32 _bskazpaddle_entrypoint_0(s32 idx);
+extern s32 _bskazpaddle_entrypoint_1(s32 idx);
+extern s32 _bskazpaddle_entrypoint_2(s32 idx);
+extern s32 _bskazpaddle_entrypoint_3(s32 idx);
+extern s32 _bskazpaddle_entrypoint_4(s32 idx);
+extern s32 _bskazpaddle_entrypoint_5(s32 idx);
 
 #endif // __BS_KAZPADDLE_H__

--- a/include/bs/kazshock.h
+++ b/include/bs/kazshock.h
@@ -15,15 +15,14 @@
 #include "bs/kazmove.h"
 #include "core2/1E29B60.h"
 #include "core2/1E66990.h"
+#include "core2/1E6B900.h"
 #include "core2/1E76CC0.h"
 #include "core2/1E93440.h"
 #include "core2/1EA0690.h"
 #include "funcs.h"
 #include "player.h"
 
-extern s32 func_8008E260(PlayerState *self);
 extern void func_80092BF4(PlayerState *self);
-extern void func_80092C24(PlayerState *self, f32[3]);
 extern s32 func_800C2E04();
 extern void func_800C2E40(s32);
 extern void func_800C2FDC(u8);
@@ -32,5 +31,7 @@ extern void func_800C330C(s32, s32);
 extern void func_800C3418(s32, s32);
 extern void func_800C3730(s32, f32, f32, f32);
 extern void func_800C3BDC(s32);
+
+extern void _bskazshock_entrypoint_0(PlayerState *self);
 
 #endif // __BS_KAZSHOCK_H__

--- a/include/bs/kazshoessuckspline.h
+++ b/include/bs/kazshoessuckspline.h
@@ -24,7 +24,6 @@ extern s32 func_8008DD04(PlayerState *self);
 extern void func_80092880(PlayerState *self, s32);
 extern void func_800956B8();
 extern void func_80099A7C(PlayerState *self, f32[3]);
-extern s32 func_8009BCD4(PlayerState *self, f32);
 extern s32 func_8009CA70(PlayerState *self, s32, s32);
 extern void func_800A2018(PlayerState *self, s32);
 

--- a/include/bs/kazspring.h
+++ b/include/bs/kazspring.h
@@ -13,9 +13,8 @@
 #include "bs/kaz.h"
 #include "core2/1E76880.h"
 #include "core2/1E76CC0.h"
+#include "core2/1ECA640.h"
 #include "funcs.h"
 #include "player.h"
-
-extern f32 func_800F1214(f32 value, f32 min, f32 max); // ml_interpolate_f
 
 #endif // __BS_KAZSPRING_H__

--- a/include/bs/kazstill.h
+++ b/include/bs/kazstill.h
@@ -16,17 +16,15 @@
 #include "ba/yaw.h"
 #include "bs/kaz.h"
 #include "bs/rest.h"
+#include "core2/1E66990.h"
 #include "core2/1E6E870.h"
 #include "core2/1E76CC0.h"
+#include "core2/1E78BF0.h"
 #include "funcs.h"
 #include "player.h"
 
-extern s32 func_8008D790(PlayerState *self);
-extern s32 func_8008DF18(PlayerState *self);
-extern s32 func_8008E39C(PlayerState *self);
 extern s32 func_8008E3E8(PlayerState *self);
 extern void func_80090A2C(PlayerState *self);
-extern BanjoStateId func_800A02DC(PlayerState *self, BanjoStateId);
 
 extern BanjoStateId _bskazstill_entrypoint_4(PlayerState *self, BanjoStateId);
 

--- a/include/bs/kazstilt.h
+++ b/include/bs/kazstilt.h
@@ -16,6 +16,7 @@
 #include "ba/physics.h"
 #include "bs/rest.h"
 #include "ba/input.h"
+#include "core2/1E66990.h"
 #include "core2/1E6F080.h"
 #include "core2/1E75710.h"
 #include "core2/1E76880.h"

--- a/include/bs/kaztorpedo.h
+++ b/include/bs/kaztorpedo.h
@@ -4,6 +4,7 @@
 #include <ultra64.h>
 
 #include "an/anctrl.h"
+#include "ba/1E72EA0.h"
 #include "ba/anim.h"
 #include "ba/duo.h"
 #include "ba/flag.h"
@@ -26,10 +27,12 @@
 #include "core2/1E6B900.h"
 #include "core2/1E6E870.h"
 #include "core2/1E6F080.h"
+#include "core2/1E75620.h"
 #include "core2/1E75710.h"
 #include "core2/1E75920.h"
 #include "core2/1E76CC0.h"
 #include "core2/1E77A20.h"
+#include "core2/1E78BF0.h"
 #include "core2/1E79FD0.h"
 #include "core2/1E7BFA0.h"
 #include "core2/1EB2840.h"
@@ -51,22 +54,15 @@ extern s32 func_80092AD8(PlayerState *self);
 extern f32 func_80092BE8(PlayerState *self);
 extern void func_800931AC(PlayerState *self, s32);
 extern void func_800947EC(PlayerState *self, s32, s32);
-extern void func_800995B8();
 extern s32 func_80099A58(PlayerState *self);
 extern f32 func_8009BB94(PlayerState *self);
-extern void func_8009BC34(PlayerState *self);
-extern void func_8009BC5C(PlayerState *self, f32);
-extern void func_8009BD88();
 extern void func_8009C000(PlayerState *self);
 extern void func_8009DA40(PlayerState *self);
 extern void func_8009E154(PlayerState *self, s32, f32 *);
 extern void func_8009E474(PlayerState *self);
 extern void func_8009E4AC(PlayerState *self);
 extern void func_8009E55C(PlayerState *self, s32, f32);
-extern s32 func_8009E69C(PlayerState *self, s32);
-extern s32 func_8009E6C4(PlayerState *self, s32);
 extern s32 bs_getCurrentState(PlayerState *self);
-extern s32 func_8009FBB0(PlayerState *self, f32[3], f32);
 extern void func_800A0DC4(PlayerState *self, s32);
 extern void func_800A16BC(s32);
 extern void func_800A3410(PlayerState *self, s32);

--- a/include/bs/kazwingwhack.h
+++ b/include/bs/kazwingwhack.h
@@ -20,7 +20,6 @@
 
 extern f32 func_80092BE8(PlayerState *self);
 extern void func_800931AC(PlayerState *self, s32);
-extern f32 func_8009BB5C(PlayerState *self);
 extern void func_8009E474(PlayerState *self);
 extern void func_8009E4AC(PlayerState *self);
 extern void func_8009E55C(PlayerState *self, s32, f32);

--- a/include/bs/ledge.h
+++ b/include/bs/ledge.h
@@ -19,18 +19,17 @@
 #include "core2/1E79FD0.h"
 #include "core2/1E7D460.h"
 #include "core2/1EB5980.h"
+#include "core2/1ECA640.h"
 #include "common.h"
 #include "funcs.h"
 
 void func_800EFD24(f32 [3]);
-f32 func_800F1214(f32 value, f32 min, f32 max); // ml_interpolate_f
 extern void func_80092880(PlayerState *self, s32);
 extern void func_8009E474(PlayerState *self);
 extern void func_800A2018(PlayerState *self, s32);
 extern void func_8009E4AC(PlayerState *self);
 extern void func_8009E53C(PlayerState *self, s32, f32);
 void func_8009E55C(PlayerState *, s32, f32);
-extern f32 func_8009BB5C(PlayerState *self);
 void func_8009FFD8(PlayerState* thisx, BaAnimUpdateType anim_update_type, YawType yaw_state, s32 arg2, BaPhysicsType arg3);
 
 void _bapackctrl_entrypoint_5(PlayerState *self, s32);

--- a/include/bs/mum.h
+++ b/include/bs/mum.h
@@ -29,10 +29,7 @@
 #include "player.h"
 #include <ultra64.h>
 
-extern s32 func_8008D544(PlayerState *self);
-extern s32 func_8008E260(PlayerState *self);
 extern void func_800947EC(PlayerState *self, s32, s32);
-extern void func_8009B7C0(PlayerState *self);
 extern void func_8009E474(PlayerState *self);
 extern void func_8009E4AC(PlayerState *self);
 extern void func_8009E53C(PlayerState *self, s32, f32);
@@ -40,8 +37,6 @@ void func_8009E55C(PlayerState *self, s32, f32);
 extern void func_8009E5A4(PlayerState *self, s32, s32);
 extern s32 bs_getCurrentState(PlayerState *self);
 void func_8009FFD8(PlayerState* thisx, BaAnimUpdateType anim_update_type, YawType yaw_state, s32 arg2, BaPhysicsType arg3);
-f32 func_800DC0C0(void);
-f32 func_800F1214(f32 value, f32 min, f32 max); // ml_interpolate_f
 s32 func_8008DE24(PlayerState *self);
 void func_80093230(PlayerState *self, f32);
 void func_800A0DAC(PlayerState *self, s32);

--- a/include/bs/mumattack.h
+++ b/include/bs/mumattack.h
@@ -12,17 +12,17 @@
 #include "ba/wandglow.h"
 #include "bs/mum.h"
 #include "bs/state.h"
+#include "core2/1E29B60.h"
 #include "core2/1E76CC0.h"
+#include "core2/1EB5980.h"
 #include "core2/1ECA640.h"
 #include "common.h"
 #include <ultra64.h>
 
-extern s32 func_8001210C(s32);
 void func_8008B10C(AnimCtrl *, f32);
 void func_8009FFD8(PlayerState* thisx, BaAnimUpdateType anim_update_type, YawType yaw_state, s32 arg2, BaPhysicsType arg3);
 void func_800C2FDC(u8 id);
 void func_800C31DC(s32 id, f32, s32);
-f32 func_800DC0C0(void);
 void func_8008B2E8(AnimCtrl *, s32);
 void func_80092C48(PlayerState *self, f32[3]);
 s32 func_8009D454(PlayerState *self, s32, s32 *);

--- a/include/bs/mummove.h
+++ b/include/bs/mummove.h
@@ -6,6 +6,7 @@
 #include "ba/drone.h"
 #include "ba/dust.h"
 #include "ba/key.h"
+#include "ba/physics.h"
 #include "ba/playerstate.h"
 #include "ba/roll.h"
 #include "ba/stick.h"
@@ -13,6 +14,7 @@
 #include "bs/mum.h"
 #include "bs/state.h"
 #include "core2/1E75710.h"
+#include "core2/1E76880.h"
 #include "core2/1E77A20.h"
 #include "core2/1E7BFA0.h"
 #include "common.h"
@@ -22,8 +24,6 @@
 void func_8008C9F0(PlayerState *self, f32, f32, f32, f32);
 void func_8008CA30(PlayerState *self, f32 scale);
 s32 func_8008DD04(PlayerState*);
-extern f32 func_8009BB5C(PlayerState *self);
-extern s32 func_8009BCD4(PlayerState *self, f32);
 extern void func_8009D2F0(PlayerState *self, s32, f32);
 void func_8009FFD8(PlayerState* thisx, BaAnimUpdateType anim_update_type, YawType yaw_state, s32 arg2, BaPhysicsType arg3);
 s32 func_8008E148(PlayerState *self);

--- a/include/bs/mumsplat.h
+++ b/include/bs/mumsplat.h
@@ -10,6 +10,7 @@
 #include "bs/splat.h"
 #include "bs/state.h"
 #include "core2/1E67DA0.h"
+#include "core2/1E75620.h"
 #include "core2/1E76CC0.h"
 #include "core2/1E7AB30.h"
 #include "common.h"
@@ -17,7 +18,6 @@
 #include <ultra64.h>
 
 s32 func_8008DD04(PlayerState*);
-extern void func_8009BD88();
 void func_8009FFD8(PlayerState* thisx, BaAnimUpdateType anim_update_type, YawType yaw_state, s32 arg2, BaPhysicsType arg3);
 
 extern s32 D_808001E0_bsmumsplat[];

--- a/include/bs/mumswim.h
+++ b/include/bs/mumswim.h
@@ -14,38 +14,27 @@
 #include "bs/mum.h"
 #include "bs/rest.h"
 #include "bs/state.h"
+#include "core2/1E29B60.h"
+#include "core2/1E6B900.h"
 #include "core2/1E6F080.h"
 #include "core2/1E75920.h"
 #include "core2/1E76880.h"
 #include "core2/1E76CC0.h"
 #include "core2/1E77A20.h"
 #include "core2/1E78BF0.h"
+#include "core2/1E7BFA0.h"
 #include "core2/1E7D460.h"
+#include "core2/1E93440.h"
+#include "core2/1EB5980.h"
 #include "core2/1ECA640.h"
 #include "common.h"
 #include "funcs.h"
 #include "player.h"
 #include <ultra64.h>
 
-extern s32 func_8001210C(s32);
 void func_8008C9F0(PlayerState *self, f32, f32, f32, f32);
 void func_8008CA4C(PlayerState *self, BaAnimUpdateType arg1);
-extern void func_80092C00(PlayerState *self, f32[3]);
-extern void func_80092C24(PlayerState *self, f32[3]);
-extern s32 func_80096500(PlayerState *self);
-extern void func_8009BC34();
-extern void func_8009BC5C(PlayerState *self, f32);
-extern void func_8009DE74(PlayerState *self, s32, f32, f32);
-extern s32 func_8009E69C(PlayerState *self, s32);
-extern s32 func_8009E6C4(PlayerState *self, s32);
-extern s32 func_8009FBB0(PlayerState *self, f32[3], f32);
-extern void func_8009FC34(PlayerState *self, s32);
 void func_8009FFD8(PlayerState* thisx, BaAnimUpdateType anim_update_type, YawType yaw_state, s32 arg2, BaPhysicsType arg3);
-extern f32 func_800A3298(PlayerState *self);
-extern void func_800BA22C(s32, s32);
-extern void func_800BA930(s32, s32, s32, s32, s32, s32, s32);
-f32 func_800DC0C0(void);
-f32 func_800F1214(f32 value, f32 min, f32 max); // ml_interpolate_f
 s32 func_80096544(PlayerState *self);
 void func_8009FD24(PlayerState *self, s32);
 

--- a/include/bs/ow.h
+++ b/include/bs/ow.h
@@ -7,12 +7,11 @@
 #include "ba/playerstate.h"
 #include "bs/state.h"
 #include "bs/walk.h"
+#include "core2/1E66990.h"
 #include "core2/1E6E870.h"
 #include "common.h"
 #include "player.h"
 #include <ultra64.h>
-
-extern s32 func_8008E260(PlayerState *self);
 
 extern s32 D_80800150_bsow[];
 

--- a/include/core2/1E29B60.h
+++ b/include/core2/1E29B60.h
@@ -51,6 +51,7 @@ extern u8 core2_DATA_END[]; // core2 data end
 extern u8 core2_BSS_START[]; // core2 bss start
 extern u8 core2_BSS_END[]; // core2 bss end
 
+s32 func_8001210C(s32);
 s32 func_8001211C(void);
 
 #endif // __CORE2_1E29B60_H__

--- a/include/core2/1E66990.h
+++ b/include/core2/1E66990.h
@@ -8,8 +8,14 @@
 
 s32 func_8008D0E0(PlayerState *);
 s32 func_8008D3B0(PlayerState *);
+s32 func_8008D544(PlayerState *);
+s32 func_8008D790(PlayerState *);
+s32 func_8008DF18(PlayerState *);
 s32 func_8008DF8C(PlayerState *, s32);
 s32 func_8008E124(PlayerState *);
+s32 func_8008E260(PlayerState *);
+s32 func_8008E39C(PlayerState *);
 s32 func_8008E430(void);
+
 
 #endif // __CORE2_1E66990_H__

--- a/include/core2/1E6B900.h
+++ b/include/core2/1E6B900.h
@@ -6,6 +6,8 @@
 #include "ba/playerstate.h"
 
 void func_80092864(PlayerState *, f32);
+void func_80092C00(PlayerState *, f32[3]);
+void func_80092C24(PlayerState *, f32[3]);
 void func_80093360(PlayerState *, f32);
 s32 func_800944E0(PlayerState *, s32);
 s32 func_80094510(PlayerState *);

--- a/include/core2/1E6EC70.h
+++ b/include/core2/1E6EC70.h
@@ -1,0 +1,11 @@
+#ifndef __CORE2_1E6EC70_H__
+#define __CORE2_1E6EC70_H__
+
+#include <ultra64.h>
+
+#include "common.h"
+#include "ba/playerstate.h"
+
+extern s32 func_8009557C(PlayerState *self);
+
+#endif // __CORE2_1E6EC70_H__

--- a/include/core2/1E6F080.h
+++ b/include/core2/1E6F080.h
@@ -14,7 +14,9 @@ void func_800962B0(PlayerState *, s32);
 void func_800963C0(PlayerState *, f32[3]);
 s32 func_80096434(PlayerState *);
 void func_80096440(PlayerState *, f32 *);
+f32 func_8009630C(PlayerState *);
 f32 func_800964DC(PlayerState *);
+s32 func_80096500(PlayerState *);
 s32 func_8009650C(PlayerState *);
 s32 func_80096628(PlayerState *);
 

--- a/include/core2/1E75620.h
+++ b/include/core2/1E75620.h
@@ -5,6 +5,7 @@
 
 #include "ba/playerstate.h"
 
+void func_8009BD88(PlayerState *);
 void func_8009BDAC(PlayerState *, f32);
 
 #endif // __CORE2_1E75620_H__

--- a/include/core2/1E76880.h
+++ b/include/core2/1E76880.h
@@ -9,6 +9,7 @@
 
 void func_8009CFD8(PlayerState *, f32);
 void func_8009D2D8(PlayerState *, s32);
-void func_8009D3A8(PlayerState *self, s32);
+void func_8009D2F0(PlayerState *, s32, f32);
+void func_8009D3A8(PlayerState *, s32);
 
 #endif // __CORE2_1E76880_H__

--- a/include/core2/1E76CC0.h
+++ b/include/core2/1E76CC0.h
@@ -13,6 +13,7 @@ void func_8009D874(PlayerState *);
 void func_8009D9D4(PlayerState *);
 void func_8009DBF0(PlayerState *, s32, f32);
 void func_8009DDDC(PlayerState *);
+void func_8009DE74(PlayerState *, s32, f32, f32);
 void func_8009DEC0(PlayerState *, s32, f32, f32, s32, s32);
 void func_8009DF18(PlayerState *, s32, f32, s32);
 void func_8009DF58(PlayerState *, s32, f32);

--- a/include/core2/1E77A20.h
+++ b/include/core2/1E77A20.h
@@ -13,6 +13,8 @@ s16 func_8009E6EC(PlayerState *);
 s32 bs_getCurrentState(PlayerState *);
 s32 bs_getNextState(PlayerState *);
 s32 bs_getPreviousState(PlayerState *);
+s32 func_8009E69C(PlayerState *, s32);
+s32 func_8009E6C4(PlayerState *, s32);
 s32 func_8009E74C(PlayerState *, s32);
 s32 func_8009E77C(PlayerState *, s32);
 void func_8009E830(PlayerState *, s32);

--- a/include/core2/1E78BF0.h
+++ b/include/core2/1E78BF0.h
@@ -4,9 +4,14 @@
 #include "ba/playerstate.h"
 #include "bs/state.h"
 
+f32 func_8009F308(PlayerState *);
 f32 func_8009F3BC(PlayerState *, f32, f32, f32, f32);
+s32 func_8009FBB0(PlayerState *, f32[3], f32);
+void func_8009FC34(PlayerState *, s32);
 void func_8009FE58(PlayerState *);
 void func_800A0180(PlayerState *);
+BanjoStateId func_800A01F8(PlayerState *, BanjoStateId arg1);
+BanjoStateId func_800A02DC(PlayerState *, BanjoStateId arg1);
 void func_800A042C(PlayerState *);
 void func_800A046C(PlayerState *);
 

--- a/include/core2/1E79FD0.h
+++ b/include/core2/1E79FD0.h
@@ -8,5 +8,7 @@
 void func_800A0D14(PlayerState *, s32, f32);
 void func_800A0CDC(PlayerState *, s32);
 void func_800A0CF4(PlayerState *, s32);
+void func_800A1040(PlayerState *);
+void func_800A106C(PlayerState *, f32, f32);
 
 #endif // __CORE2_1E79FD0_H__

--- a/include/core2/1E7BFA0.h
+++ b/include/core2/1E7BFA0.h
@@ -8,6 +8,8 @@
 #include "ba/playerstate.h"
 
 void func_800A2CE8(PlayerState *, f32, s32);
+void func_800A2D2C(PlayerState *, f32, s32);
+f32 func_800A3298(PlayerState *);
 void func_800A32C4(PlayerState *, f32[3]);
 void func_800A34AC(PlayerState *, f32[3]);
 

--- a/include/core2/1E93440.h
+++ b/include/core2/1E93440.h
@@ -4,5 +4,7 @@
 #include <ultra64.h>
 
 void func_800BBCB8(f32[3], s32, f32, s32, s32 *);
+void func_800BA22C(s32, s32);
+void func_800BA930(s32, s32, s32, s32, s32, s32, s32);
 
 #endif // __CORE2_1E93440_H__

--- a/include/core2/1EDA900.h
+++ b/include/core2/1EDA900.h
@@ -1,0 +1,10 @@
+#ifndef __CORE2_1EDA900_H__
+#define __CORE2_1EDA900_H__
+
+#include "common.h"
+
+#include <ultra64.h>
+
+extern s32 func_8010114C(s32, s32, s32);
+
+#endif // __CORE2_1EDA900_H__

--- a/include/core2/physics.h
+++ b/include/core2/physics.h
@@ -1,0 +1,10 @@
+#ifndef __CORE2_PHYSICS_H__
+#define __CORE2_PHYSICS_H__
+
+#include "common.h"
+
+#include <ultra64.h>
+
+#include "ba/playerstate.h"
+
+#endif // __CORE2_PHYSICS_H__

--- a/src/core1/crc.c
+++ b/src/core1/crc.c
@@ -1,10 +1,10 @@
 #include "types.h"
+#include "ba/physics.h"
 
 void init_crc_check();
 void ovl_entrypoint();
 void func_800A1364();
 void func_800965D4();
-void func_8009B7C0();
 void func_8001C1C0();
 void func_800CFA90();
 void func_800D1510();

--- a/src/core2/1E6EC70.c
+++ b/src/core2/1E6EC70.c
@@ -1,4 +1,4 @@
-#include "common.h"
+#include "core2/1E6EC70.h"
 
 #pragma GLOBAL_ASM("asm/nonmatchings/core2/1E6EC70/func_80095380.s")
 

--- a/src/core2/1E75620.c
+++ b/src/core2/1E75620.c
@@ -1,4 +1,4 @@
-#include "common.h"
+#include "core2/1E75620.h"
 
 #pragma GLOBAL_ASM("asm/nonmatchings/core2/1E75620/func_8009BD30.s")
 

--- a/src/core2/1E78BF0.c
+++ b/src/core2/1E78BF0.c
@@ -50,10 +50,8 @@
 
 #pragma GLOBAL_ASM("asm/nonmatchings/core2/1E78BF0/func_800A0180.s")
 
-BanjoState func_800A01F8(PlayerState *self, BanjoState arg1);
 #pragma GLOBAL_ASM("asm/nonmatchings/core2/1E78BF0/func_800A01F8.s")
 
-BanjoState func_800A02DC(PlayerState *self, BanjoState arg1);
 #pragma GLOBAL_ASM("asm/nonmatchings/core2/1E78BF0/func_800A02DC.s")
 
 #pragma GLOBAL_ASM("asm/nonmatchings/core2/1E78BF0/func_800A042C.s")

--- a/src/core2/1EB3750.c
+++ b/src/core2/1EB3750.c
@@ -1,10 +1,10 @@
 #include <ultra64.h>
 #include "memory.h"
+#include "core2/1E29B60.h"
 
 void _gldbDll_entrypoint_1(void);
 void _gldbDll_entrypoint_2(void);
 s32 _glgamedata_entrypoint_3(u8*, s32, s32*, u32*);
-u32 func_8001210C(u32);
 
 // .data
 u32 D_8011B990 = 0;

--- a/src/core2/1EDA900.c
+++ b/src/core2/1EDA900.c
@@ -1,4 +1,4 @@
-#include "common.h"
+#include "core2/1EDA900.h"
 
 #pragma GLOBAL_ASM("asm/nonmatchings/core2/1EDA900/func_80101010.s")
 

--- a/src/core2/bainput.c
+++ b/src/core2/bainput.c
@@ -4,6 +4,7 @@
 
 #include "ba/key.h"
 #include "ba/flag.h"
+#include "core2/1E66990.h"
 #include "core2/1EA0690.h"
 #include "core2/1EB2840.h"
 #include "core2/1ECA640.h"

--- a/src/core2/baphysics.c
+++ b/src/core2/baphysics.c
@@ -1,4 +1,4 @@
-#include "common.h"
+#include "ba/physics.h"
 
 #pragma GLOBAL_ASM("asm/nonmatchings/core2/baphysics/func_8009AD70.s")
 

--- a/src/overlays/babounce/babounce.c
+++ b/src/overlays/babounce/babounce.c
@@ -11,11 +11,13 @@
 #include "core2/1E2B200.h"
 #include "core2/1E67DA0.h"
 #include "core2/1E6E870.h"
+#include "core2/1E75620.h"
 #include "core2/1E75920.h"
 #include "core2/1E76CC0.h"
 #include "core2/1E78BF0.h"
 #include "core2/1E7BFA0.h"
 #include "core2/1ECB0F0.h"
+#include "core2/1EDA900.h"
 
 s32 babounce_entrypoint_0(void) {
     return sizeof(BaBounce);

--- a/src/overlays/badata/badata.c
+++ b/src/overlays/badata/badata.c
@@ -1,69 +1,4 @@
-#include <ultra64.h>
-#include "common.h"
-
-#include "ba/playerstate.h"
-
-#include "ba/statetimer.h"
-#include "core2/1E6F080.h"
-#include "core2/1E75920.h"
-#include "core2/1EB5980.h"
-
-typedef struct {
-    s16 unk0;
-    s16 unk2;
-    f32 unk4;
-} BaData_1;
-
-typedef struct {
-    BaData_1 *unk0;
-    s32 count;
-    f32 unk8;
-} BaData_5;
-
-typedef struct {
-    s16 unk0;
-    s16 unk2;
-    f32 unk4;
-    f32 unk8;
-} BaData_4;
-
-typedef struct {
-    s16 unk0;
-    s16 unk2;
-    f32 unk4;
-    f32 unk8;
-    f32 unkC;
-} BaData_3;
-
-typedef struct {
-    s16 unk0;
-    s16 unk2;
-    s16 unk4;
-} BaData_2;
-
-extern BaData_5 D_808010C8_badata[];
-extern BaData_5 D_80801298_badata[];
-extern s16 D_80801448_badata[];
-extern s16 D_80801490_badata[];
-extern s16 D_808014D8_badata[];
-extern s16 D_80801520_badata[];
-extern BaData_2 D_80801568_badata[];
-extern u8 D_80801640_badata[];
-extern u8 D_80801664_badata[];
-extern s32 D_80801688_badata[];
-extern BaData_3 D_80801718_badata[];
-extern BaData_1 D_80801958_badata[];
-extern BaData_1 D_80801A78_badata[];
-extern BaData_1 D_80801B98_badata[];
-extern BaData_1 D_80801CB8_badata[];
-extern BaData_1 D_80801DD8_badata[];
-extern BaData_1 D_80801EF8_badata[];
-extern BaData_1 D_80802018_badata[];
-extern BaData_1 D_80802138_badata[];
-extern BaData_1 D_80802258_badata[];
-extern BaData_1 D_80802378_badata[];
-extern BaData_4 D_80802498_badata[];
-extern BaData_4 D_80802648_badata[];
+#include "ba/data.h"
 
 s32 func_80800000_badata(PlayerState *self) {
     s32 sp1C  = bs_getCurrentState(self);
@@ -324,28 +259,28 @@ void func_808006AC_badata(PlayerState *self , BaData_1 *arg1, s32 *arg2, f32 *ar
 }
 
 
-void badata_entrypoint_0(PlayerState *self, s32 *arg1, f32 *arg2) {
-    func_808006AC_badata(self, D_80801EF8_badata, arg1, arg2);
+void badata_entrypoint_0(PlayerState *self, AssetId *assetId, f32 *arg2) {
+    func_808006AC_badata(self, D_80801EF8_badata, assetId, arg2);
 }
 
-void badata_entrypoint_1(PlayerState *self, s32 *arg1, f32 *arg2) {
-    func_808006AC_badata(self, D_80801A78_badata, arg1, arg2);
+void badata_entrypoint_1(PlayerState *self, AssetId *assetId, f32 *arg2) {
+    func_808006AC_badata(self, D_80801A78_badata, assetId, arg2);
 }
 
-void badata_entrypoint_2(PlayerState *self, s32 *arg1, f32 *arg2) {
-    func_808006AC_badata(self, D_80801B98_badata, arg1, arg2);
+void badata_entrypoint_2(PlayerState *self, AssetId *assetId, f32 *arg2) {
+    func_808006AC_badata(self, D_80801B98_badata, assetId, arg2);
 }
 
-void badata_entrypoint_3(PlayerState *self, s32 *arg1, f32 *arg2) {
-    func_808006AC_badata(self, D_80801DD8_badata, arg1, arg2);
+void badata_entrypoint_3(PlayerState *self, AssetId *assetId, f32 *arg2) {
+    func_808006AC_badata(self, D_80801DD8_badata, assetId, arg2);
 }
 
-void badata_entrypoint_4(PlayerState *self, s32 *arg1, f32 *arg2) {
-    func_808006AC_badata(self, D_80802018_badata, arg1, arg2);
+void badata_entrypoint_4(PlayerState *self, AssetId *assetId, f32 *arg2) {
+    func_808006AC_badata(self, D_80802018_badata, assetId, arg2);
 }
 
-void badata_entrypoint_5(PlayerState *self, s32 *arg1, f32 *arg2) {
-    func_808006AC_badata(self, D_80801CB8_badata, arg1, arg2);
+void badata_entrypoint_5(PlayerState *self, AssetId *assetId, f32 *arg2) {
+    func_808006AC_badata(self, D_80801CB8_badata, assetId, arg2);
 }
 
 
@@ -358,8 +293,8 @@ void badata_entrypoint_6(PlayerState *self, s32 *arg1, f32 *arg2, f32 *arg3, f32
     *arg4  = tmp_v1->unkC;
 }
 
-void badata_entrypoint_7(PlayerState * self, s32 *arg1, f32 *arg2) {
-    func_808006AC_badata(self, D_80801958_badata, arg1, arg2);
+void badata_entrypoint_7(PlayerState * self, AssetId *assetId, f32 *arg2) {
+    func_808006AC_badata(self, D_80801958_badata, assetId, arg2);
 }
 
 void badata_entrypoint_8(PlayerState *self, s32 *arg1, f32 *arg2, f32 *arg3) {
@@ -370,16 +305,16 @@ void badata_entrypoint_8(PlayerState *self, s32 *arg1, f32 *arg2, f32 *arg3) {
     *arg3  = tmp_v1->unk8;
 }
 
-void badata_entrypoint_9(PlayerState *self, s32 *arg1, f32 *arg2){
-    func_808006AC_badata(self, D_80802138_badata, arg1, arg2);
+void badata_entrypoint_9(PlayerState *self, AssetId *assetId, f32 *arg2){
+    func_808006AC_badata(self, D_80802138_badata, assetId, arg2);
 }
 
-void badata_entrypoint_10(PlayerState *self, s32 *arg1, f32 *arg2){
-    func_808006AC_badata(self, D_80802378_badata, arg1, arg2);
+void badata_entrypoint_10(PlayerState *self, AssetId *assetId, f32 *arg2){
+    func_808006AC_badata(self, D_80802378_badata, assetId, arg2);
 }
 
-void badata_entrypoint_11(PlayerState *self, s32 *arg1, f32 *arg2){
-    func_808006AC_badata(self, D_80802258_badata, arg1, arg2);
+void badata_entrypoint_11(PlayerState *self, AssetId *assetId, f32 *arg2){
+    func_808006AC_badata(self, D_80802258_badata, assetId, arg2);
 }
 
 void badata_entrypoint_12(PlayerState *self, s32 *arg1, f32 *arg2) {

--- a/src/overlays/bsbanpackwhack/bsbanpackwhack.c
+++ b/src/overlays/bsbanpackwhack/bsbanpackwhack.c
@@ -11,6 +11,7 @@
 
 #include "core2/1E76CC0.h"
 #include "core2/1E77A20.h"
+#include "core2/1E93440.h"
 #include "core2/1ECA640.h"
 
 extern s32 D_808004D0_bsbanpackwhack;

--- a/src/overlays/bsbflap/bsbflap.c
+++ b/src/overlays/bsbflap/bsbflap.c
@@ -10,6 +10,7 @@
 #include "ba/stick.h"
 #include "ba/1E72EA0.h"
 #include "bs/state.h"
+#include "core2/1E66990.h"
 #include "core2/1E76CC0.h"
 #include "core2/1E78BF0.h"
 #include "core2/1E79FD0.h"

--- a/src/overlays/bsbflip/bsbflip.c
+++ b/src/overlays/bsbflip/bsbflip.c
@@ -7,6 +7,7 @@
 #include "ba/stick.h"
 #include "ba/1E72EA0.h"
 #include "bs/state.h"
+#include "core2/1E66990.h"
 #include "core2/1E76880.h"
 #include "core2/1E76CC0.h"
 #include "core2/1E78BF0.h"

--- a/src/overlays/bskazglide/bskazglide.c
+++ b/src/overlays/bskazglide/bskazglide.c
@@ -2,12 +2,6 @@
 
 #include "bs/kazglide.h"
 
-extern s32 D_80800AB0_bskazglide[];
-extern s32 D_80800AC0_bskazglide[];
-extern s32 D_80800AD0_bskazglide[];
-extern s32 D_80800AE0_bskazglide[];
-extern s32 D_80800AF0_bskazglide[];
-
 void func_80800000_bskazglide(PlayerState *self) {
     if (func_8009E69C(self, 0x200) == 0) {
         baphysics_reset_gravity(self);
@@ -135,7 +129,7 @@ s32 bskazglide_entrypoint_0(s32 idx) {
 }
 
 void func_8080050C_bskazglide(PlayerState *self) {
-    func_8009BC34();
+    func_8009BC34(self);
     func_8008E95C(self);
     func_8009BD88(self);
     func_80800000_bskazglide(self);

--- a/src/overlays/bskazhatch/bskazhatch.c
+++ b/src/overlays/bskazhatch/bskazhatch.c
@@ -1,8 +1,4 @@
-#include "common.h"
-
 #include "bs/kazhatch.h"
-
-extern s32 D_808004E0_bskazhatch[];
 
 void func_80800000_bskazhatch(PlayerState *self, s32 arg1) {
     switch (arg1) {

--- a/src/overlays/bskazmove/bskazmove.c
+++ b/src/overlays/bskazmove/bskazmove.c
@@ -2,10 +2,6 @@
 
 #include "bs/kazmove.h"
 
-extern s32 D_80800C70_bskazmove[];
-extern s32 D_80800C80_bskazmove[];
-
-
 void func_80800000_bskazmove(PlayerState *self, f32 *arg1, f32 *arg2) {
     switch ( _bashoes_entrypoint_1(self)) {
         case 3:

--- a/src/overlays/bskazpaddle/bskazpaddle.c
+++ b/src/overlays/bskazpaddle/bskazpaddle.c
@@ -44,7 +44,7 @@ void func_80800100_bskazpaddle(PlayerState *self) {
 }
 
 void func_80800164_bskazpaddle(PlayerState *self) {
-    func_8009BC34();
+    func_8009BC34(self);
     func_800961AC(self, 1);
 }
 
@@ -137,10 +137,10 @@ void func_80800518_bskazpaddle(PlayerState *self) {
     func_80092C00(self, sp24);
     func_808003F4_bskazpaddle(self, sp24);
     if (anctrl_isAt(animCtrl, 0.2) != 0) {
-        func_8009DE74(self, 0x40C, 0.9, 1.1);
+        func_8009DE74(self, 0x40C, 0.9f, 1.1f);
     }
     if (anctrl_isAt(animCtrl, 0.7) != 0) {
-        func_8009DE74(self, 0x40C, 0.9, 1.1);
+        func_8009DE74(self, 0x40C, 0.9f, 1.1f);
     }
     func_80800100_bskazpaddle(self);
     if (bastick_getZone(self) == BS_STICK_ZONE_ID_0) {

--- a/src/overlays/bskaztorpedo/bskaztorpedo.c
+++ b/src/overlays/bskaztorpedo/bskaztorpedo.c
@@ -206,9 +206,9 @@ void func_8080078C_bskaztorpedo(PlayerState *self) {
     }
 }
 
-void func_8080088C_bskaztorpedo(PlayerState *self) {
-    func_800995B8();
-    if (bs_getCurrentState(self) != 0x15A) {
+void func_8080088C_bskaztorpedo(PlayerState *self, s32 arg1) {
+    func_800995B8(self, arg1);
+    if (bs_getCurrentState(self) != BS_STATE_15A) {
         bs_setState(self, BS_STATE_15A);
         func_8009E830(self, 2);
     }
@@ -480,7 +480,7 @@ s32 bskaztorpedo_entrypoint_6(s32 idx) {
 }
 
 void func_80801484_bskaztorpedo(PlayerState *self) {
-    func_8009BD88();
+    func_8009BD88(self);
     func_8008E95C(self);
     func_800951B4(self);
     yaw_setIdeal(self, func_80092BE8(self));

--- a/src/overlays/bsmumswim/bsmumswim.c
+++ b/src/overlays/bsmumswim/bsmumswim.c
@@ -49,7 +49,7 @@ void func_80800198_bsmumswim(PlayerState *self) {
 }
 
 void bsmumswim_entrypoint_0(PlayerState *self) {
-    func_8009BC34();
+    func_8009BC34(self);
     func_800961AC(self, 1);
     _bsmum_entrypoint_1(self);
 }

--- a/src/overlays/bstwirl/bstwirl.c
+++ b/src/overlays/bstwirl/bstwirl.c
@@ -10,6 +10,7 @@
 
 #include "ba/1E72EA0.h"
 #include "core2/1E76CC0.h"
+#include "core2/1E78BF0.h"
 #include "core2/1E79FD0.h"
 #include "core2/1EA0690.h"
 #include "core2/1EB5980.h"


### PR DESCRIPTION
Followup of https://github.com/Mr-Wiseguy/banjo-tooie/pull/15

This time it moves the functions from:
- include/bs/kazpaddle.h
- include/bs/kazow.h
- include/bs/kazmove.h
- include/bs/kazjump.h
- include/bs/kazhatch.h
- include/bs/kazglide.h