### PR TITLE
PoC: Restructure overlay files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,8 @@ ASM_PROC := $(PYTHON3_BIN) tools/asm-processor/asm_processor.py
 
 OPT_LEVEL := -O2
 CFLAGS    := -c -Wab,-r4300_mul -non_shared -G 0 -Xcpluscomm $(OPT_LEVEL) -mips2 -woff 807
-CPPFLAGS  := -I include -I $(ULTRALIB_DIR)/include -DBUILD_VERSION=VERSION_$(ULTRALIB_VERSION) -D_FINALROM -DF3DEX_GBI_2
+# The find command below finds all unique directories in the src directory that contain .h files
+CPPFLAGS  := $(shell find $(SRC_ROOT) -type f -name "*.h" -exec dirname \{\} \; | sort -u | awk '{print "-I " $$0}' | tr '\n' ' ') -I include -I $(ULTRALIB_DIR)/include -DBUILD_VERSION=VERSION_$(ULTRALIB_VERSION) -D_FINALROM -DF3DEX_GBI_2
 ASFLAGS   := -march=vr4300 -mabi=32 -mgp32 -mfp32 -mips3 -mno-abicalls -G0 -fno-pic -gdwarf -c -x assembler-with-cpp -D_LANGUAGE_ASSEMBLY
 LDFLAGS   := -nostdlib -T undefined_syms.us.txt --build-id=none --emit-relocs --whole-archive --no-warn-mismatch
 BINOFLAGS := -I binary -O elf32-tradbigmips

--- a/Makefile
+++ b/Makefile
@@ -60,8 +60,8 @@ ASM_PROC := $(PYTHON3_BIN) tools/asm-processor/asm_processor.py
 
 OPT_LEVEL := -O2
 CFLAGS    := -c -Wab,-r4300_mul -non_shared -G 0 -Xcpluscomm $(OPT_LEVEL) -mips2 -woff 807
-# The find command below finds all unique directories in the src directory that contain .h files
-CPPFLAGS  := $(shell find $(SRC_ROOT) -type f -name "*.h" -exec dirname \{\} \; | sort -u | awk '{print "-I " $$0}' | tr '\n' ' ') -I include -I $(ULTRALIB_DIR)/include -DBUILD_VERSION=VERSION_$(ULTRALIB_VERSION) -D_FINALROM -DF3DEX_GBI_2
+INCLUDE_DIRS := src/overlays/an src/overlays/ge include $(ULTRALIB_DIR)/include
+CPPFLAGS  := $(addprefix -I ,$(INCLUDE_DIRS)) -DBUILD_VERSION=VERSION_$(ULTRALIB_VERSION) -D_FINALROM -DF3DEX_GBI_2
 ASFLAGS   := -march=vr4300 -mabi=32 -mgp32 -mfp32 -mips3 -mno-abicalls -G0 -fno-pic -gdwarf -c -x assembler-with-cpp -D_LANGUAGE_ASSEMBLY
 LDFLAGS   := -nostdlib -T undefined_syms.us.txt --build-id=none --emit-relocs --whole-archive --no-warn-mismatch
 BINOFLAGS := -I binary -O elf32-tradbigmips

--- a/baserom.us.yaml
+++ b/baserom.us.yaml
@@ -631,13 +631,13 @@ segments:
     start: 0x01F01720
     extract: False
   - name: anseq
-    dir: overlays/anseq
+    dir: overlays/an/
     type: code
     vram: 0x80800000
     start: 0x01F017C0
     exclusive_ram_id: overlay
     subsegments: 
-      - [auto, c, anseq]
+      - [auto, c, seq]
   - name: seqdefine_header
     dir: overlays/seqdefine
     type: bin
@@ -15356,7 +15356,7 @@ segments:
     start: 0x0214CD60
     extract: False
   - name: gemarkersDll
-    dir: overlays/gemarkersDll
+    dir: overlays/ge
     type: code
     vram: 0x80800000
     start: 0x0214CDC0
@@ -15365,10 +15365,10 @@ segments:
     symbol_name_format: $VRAM_$SEG
     symbol_name_format_no_rom: $VRAM_$SEG
     subsegments: 
-      - [0x0214CDC0, c, gemarkersDll]
-      - [0x0214CE50, .rodata, gemarkersDll]
-      - [0x0214CE50, data, gemarkersDll]
-      - [0x0214E090, bss, gemarkersDll]
+      - [0x0214CDC0, c, markersDll]
+      - [0x0214CE50, .rodata, markersDll]
+      - [0x0214CE50, data, markersDll]
+      - [0x0214E090, bss, markersDll]
   - name: suexpressjoint_header
     dir: overlays/suexpressjoint
     type: bin

--- a/include/common.h
+++ b/include/common.h
@@ -1,4 +1,6 @@
 #ifndef __COMMON_H__
 #define __COMMON_H__
 
-#endif
+#include "types.h"
+
+#endif // __COMMON_H__

--- a/src/overlays/an/seq.c
+++ b/src/overlays/an/seq.c
@@ -1,7 +1,4 @@
-#include "common.h"
-#include "types.h"
-#include "an/anctrl.h"
-#include "vector.h"
+#include "seq.h"
 
 void anseq_entrypoint_1(s16 * pSeqIndx, s32 arg1);
 
@@ -16,12 +13,12 @@ typedef struct{
     s32 arg2;
     s32 arg3;
     void *func_ptr; //function_ptr
-}AnSeqElement;
+} AnSeqElement;
 
 struct {
     s32 unk0;
     AnSeqElement *unk4;
-}B_80800490_anseq;
+} B_80800490_anseq;
 
 void func_80800000_anseq(s16 *pSeqIndx, AnSeqElement *element) {
     if (element->unk6) {

--- a/src/overlays/an/seq.h
+++ b/src/overlays/an/seq.h
@@ -1,0 +1,9 @@
+#ifndef __AN_SEQ_H__
+#define __AN_SEQ_H__
+
+#include "common.h"
+#include "types.h"
+#include "an/anctrl.h"
+#include "vector.h"
+
+#endif // __AN_SEQ_H__

--- a/src/overlays/ge/markersDll.c
+++ b/src/overlays/ge/markersDll.c
@@ -1,0 +1,5 @@
+#include "markersDll.h"
+
+#pragma GLOBAL_ASM("asm/nonmatchings/overlays/ge/markersDll/gemarkersDll_entrypoint_0.s")
+
+#pragma GLOBAL_ASM("asm/nonmatchings/overlays/ge/markersDll/gemarkersDll_entrypoint_1.s")

--- a/src/overlays/ge/markersDll.h
+++ b/src/overlays/ge/markersDll.h
@@ -1,0 +1,6 @@
+#ifndef __GE_MARKERS_DLL_H__
+#define __GE_MARKERS_DLL_H__
+
+#include "common.h"
+
+#endif // __GE_MARKERS_DLL_H__

--- a/src/overlays/gemarkersDll/gemarkersDll.c
+++ b/src/overlays/gemarkersDll/gemarkersDll.c
@@ -1,5 +1,0 @@
-#include "common.h"
-
-#pragma GLOBAL_ASM("asm/nonmatchings/overlays/gemarkersDll/gemarkersDll/gemarkersDll_entrypoint_0.s")
-
-#pragma GLOBAL_ASM("asm/nonmatchings/overlays/gemarkersDll/gemarkersDll/gemarkersDll_entrypoint_1.s")


### PR DESCRIPTION
This PR aims to set a new structure of how we can / should handle the files inside of the overlays directory.

I tested this for overlays/anseq.c and overlays/gemarkersDll.c as they were quite small and showed both cases of "fully decomped" and "not decomped at all" to also show off the new paths for the nonmatchings asm path.

In an ideal world I would've also changed the `tools/overlay_processor.cpp` to check for both path versions (so both `output_path + "overlays/" + ovl.name + "/" + ovl.name + "_header.s"` as well as `output_path + "overlays/" + <prefix of ovl.name>+ "/" + <other patrt of ovl.name> + "_header.s"` but my C++ knowledge is too limited to fix this.


I also looked into how we could structure things and came up with the following directories:
The format is "path (total number of .c files)". If the directory is the same name as another file (e.g. bsdrone.c) both the `bs/drone` directory is created and all "grouped" files put into there as well as `drone.c` being placed into the `bs/` directory.

The `bs/b` group is probably not something we should use, however those files do all share the b "prefix".

The directories are all 2-letter directories except "seq".

- an/ (1)
- ba/ (48)
- ba/egg/ (4)
- ba/move/ (5)
- bs/ (45)
- bs/ban/ (6)
- bs/b/ barge, billdrill, buster, flap, flip, fly, longleg, peck, reegullbash, shock, swim, trot, whirl (13)
- bs/drone/ (12 + drone.c)
- bs/kaz/ (20 + kaz.c)
- bs/mum/ (6 + mum.c)
- ca/ (4)
- ch/ (163)
- ch/anglerboss (3 + anglerboss.c)
- ch/bad (5)
- ch/boggy (6 + boggy.c)
- ch/boiler (3)
- ch/bottles (4)
- ch/digger (9)
- ch/dino (12)
- ch/egg (8)
- ch/factory (27)
- ch/fair (3)
- ch/fantasy (10)
- ch/fire (4)
- ch/gobi (3)
- ch/gold (3)
- ch/grunty (3)
- ch/hot (3)
- ch/intro (4)
- ch/jiggy (4)
- ch/jigsaw (3 + jigsaw.c)
- ch/klungo (5 + klungo.c)
- ch/lagoon (9)
- ch/lava (16)
- ch/light (3)
- ch/mine (8)
- ch/mole (11)
- ch/mumbo (5)
- ch/starspinner (3)
- ch/temple (4)
- ch/tnt (6)
- ch/waterfall (3)
- ch/weldarboss (3)
- ch/witchy (3)
- co/ (3)
- db/ (11)
- fx/ (17)
- gc/ (25)
- gc/dialog (3)
- gc/mapsects (3 + mapsects.c)
- ge/ (1)
- gl/ (20)
- gl/spline (5)
- gs/ (8)
- gz/ (4)
- id/ (17)
- in/ (4)
- ml/ (2)
- nc/ (2)
- nc/ba/ (23)
- nc/pod/ (3 + pod.c)
- pl/ (2)
- rt (2)
- sc/ (5)
- seq/ (2)
- su/ (28)
- su/baddie/ (24)
- su/coaster/ (5 + coaster.c)
- tr/ (1)
- vp/ (6)